### PR TITLE
Add jsDelivr links

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ The first step is to include the library file in an HTML document.
 
 <!-- if you prefer to use CDN -->
 <script src="https://cdn.rawgit.com/google/songbird/master/build/songbird.min.js"></script>
+or
+<script src="https://cdn.jsdelivr.net/npm/songbird-audio/build/songbird.min.js"></script>
 ```
 
 Spatial encoding is done by creating a `Songbird` scene using an associated


### PR DESCRIPTION
[jsDelivr](https://www.jsdelivr.com/) is the [fastest opensource cdn](https://www.cdnperf.com/) available and built specifically for production usage. It can serve any project from npm with zero config. This PR adds it to the readme as an alternative to RawGit.